### PR TITLE
ISpreadsheet.php updated to comply with psr-4 autoloading 

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,14 @@ The most common way to use this is to access if via the Craft Control Panel unde
 
 ### Via Command Line
 
-To run a sync, you call it via yiic:
+To run a sync, first navigate to the folder in /var/www/ that has craft. Then 
 
 ```
-$ php craft/app/etc/console/yiic  --sync=name-of-a-sync
+$ php craft sheet-sync/default/sync --name='name-of-a-sync'
 ```
 
 You can optionally specify a specific file to use:
 
 ```
-$ php craft/app/etc/console/yiic sheetsync --sync=name-of-a-sync --file=path/to/file
+$ php craft sheet-sync/default/sync --name='name-of-a-sync' --file=path/to/file
 ```

--- a/src/services/ISpreadsheet.php
+++ b/src/services/ISpreadsheet.php
@@ -2,7 +2,7 @@
 
 namespace imarc\sheetsync\services;
 
-interface ISpreadSheet
+interface ISpreadsheet
 {
     public function __construct($filename);
     public function getRow();

--- a/src/services/PlainCsv.php
+++ b/src/services/PlainCsv.php
@@ -2,7 +2,7 @@
 
 namespace imarc\sheetsync\services;
 
-class PlainCsv implements ISpreadSheet
+class PlainCsv implements ISpreadsheet
 {
     private $filename = null;
     private $file = null;

--- a/src/services/Spreadsheet.php
+++ b/src/services/Spreadsheet.php
@@ -4,7 +4,7 @@ namespace imarc\sheetsync\services;
 
 use PhpOffice\PhpSpreadsheet\IOFactory;
 
-class Spreadsheet implements ISpreadSheet
+class Spreadsheet implements ISpreadsheet
 {
     private $row_iterator = null;
     private $labels = null;


### PR DESCRIPTION
The Sheet Sync plugin stopped working correctly sometime before April 16th. 

This error was found in phperrors.log: 

  [29-Mar-2021 05:30:09 America/New_York] PHP Fatal error:  Interface 'imarc\sheetsync\services\ISpreadSheet' not found in /var/www/infor.com/stage/vendor/imarc/craft-sheetsync/src/services/PlainCsv.php on line 5

Upon searching the build log, this error was found:

[30;43mClass imarc\sheetsync\services\ISpreadSheet located in ./vendor/imarc/craft-sheetsync/src/services/ISpreadsheet.php does not comply with psr-4 autoloading standard. Skipping.

I have updated ISpreadsheet.php to be compliant with psr-4 autoloading.

Also, when trying to run the Sheet Sync from the command line, I found that the Readme was no longer accurate, so I updated it with the working command.